### PR TITLE
Remove unnecessary comments, add default locking state, add notification when locking/unlocking

### DIFF
--- a/betterBuilding/src/main/java/legobrosbuild/betterbuilding/BetterBuilding.java
+++ b/betterBuilding/src/main/java/legobrosbuild/betterbuilding/BetterBuilding.java
@@ -19,7 +19,6 @@ public class BetterBuilding implements ModInitializer {
         Registry.register(Registry.ITEM, new Identifier("betterbuilding", "wood_wand"), WOOD_WAND);
 
         ServerPlayNetworking.registerGlobalReceiver(LOCK_WAND_ID, (server, player, handler, buf, responseSender) -> {
-            // PenguinEncounter says: store LOCK_WAND_ID in BetterBuilding.java, not BetterBuildingClient.java
 
             boolean lockedState = buf.readBoolean();
             if (WoodWand.lockedState.containsKey(player.getUuid())){
@@ -28,7 +27,6 @@ public class BetterBuilding implements ModInitializer {
             else {
                 WoodWand.lockedState.put(player.getUuid(), lockedState); //Only used first time the button is pressed
             }
-
         });
 
     }

--- a/betterBuilding/src/main/java/legobrosbuild/betterbuilding/WoodWand.java
+++ b/betterBuilding/src/main/java/legobrosbuild/betterbuilding/WoodWand.java
@@ -77,6 +77,11 @@ public class WoodWand extends Item {
                     Pattern pattern = Pattern.compile("(\\w)+_(\\w)+"); // REGEX
                     Matcher matcher = pattern.matcher(selectedBlock); // REGEX match
 
+                    if (!lockedState.containsKey(playerEntity.getUuid())) {
+                        // default off
+                        lockedState.put(playerEntity.getUuid(), false);
+                    }
+
                     if (matcher.find()) {
                         String result = matcher.group();
                         String sel = "Currently Selected: " + result + "    Locked: " + lockedState.get(playerEntity.getUuid()); // Selected block
@@ -86,17 +91,13 @@ public class WoodWand extends Item {
                     world.setBlockState(blockPos, plankList.get(woodNum).getDefaultState()); // Sets block
 
 
-                    if (lockedState.get(playerEntity.getUuid()) == false){
+                    if (!lockedState.get(playerEntity.getUuid())){
                         woodNum++;
                     }
                 }
 
                 break;
         }
-
-        /* Wrong place for this. Try BetterBuilding.onInitialize? This will run every time the player uses the item,
-           and will create extra handlers. Also, the player won't be able to lock the item before the player uses it.
-        */
 
         return TypedActionResult.success(playerEntity.getStackInHand(hand));
     }

--- a/betterBuilding/src/main/java/legobrosbuild/betterbuilding/client/BetterBuildingClient.java
+++ b/betterBuilding/src/main/java/legobrosbuild/betterbuilding/client/BetterBuildingClient.java
@@ -14,6 +14,7 @@ import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.option.StickyKeyBinding;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.text.LiteralText;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import org.lwjgl.glfw.GLFW;
 
@@ -33,12 +34,14 @@ public class BetterBuildingClient implements ClientModInitializer {
 
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
             while (keyBinding.wasPressed()) {
-
+                locked = !locked;  // Flip *before* sending??
                 PacketByteBuf buf = PacketByteBufs.create();
                 buf.writeBoolean(locked);
                 ClientPlayNetworking.send(BetterBuilding.LOCK_WAND_ID, buf);
-
-                locked = !locked;
+                assert client.player != null;
+                // condition ? (result if true) : (result if false)
+                // Look up "ternary operator"
+                client.player.sendMessage(new LiteralText(locked ? "Locked" : "Unlocked").formatted(locked ? Formatting.GREEN : Formatting.RED), true);
             }
         });
 


### PR DESCRIPTION
1. removed comments about moving things / todo items that have been completed
2. if the player UUID is not already in the HashMap, register with unlocked when using
3. add actionbar message (`Locked`/`Unlocked`) when using keybind
4. Switch lock state on client _before_ sending packet