### PR TITLE
Patch 2 - persist state through disconnects

### DIFF
--- a/betterBuilding/src/main/java/legobrosbuild/betterbuilding/BetterBuilding.java
+++ b/betterBuilding/src/main/java/legobrosbuild/betterbuilding/BetterBuilding.java
@@ -14,6 +14,8 @@ public class BetterBuilding implements ModInitializer {
     public static final WoodWand WOOD_WAND = new WoodWand(new FabricItemSettings().group(ItemGroup.MISC));
 
     public static final Identifier LOCK_WAND_ID = new Identifier("betterbuilding", "lockwand");
+    public static final Identifier SET_PLANK_ID = new Identifier("betterbuilding", "setplank");
+    public static final Identifier GET_CURRENT_PLANK = new Identifier("betterbuilding", "getplank");
     @Override
     public void onInitialize() {
         Registry.register(Registry.ITEM, new Identifier("betterbuilding", "wood_wand"), WOOD_WAND);
@@ -26,6 +28,16 @@ public class BetterBuilding implements ModInitializer {
             }
             else {
                 WoodWand.lockedState.put(player.getUuid(), lockedState); //Only used first time the button is pressed
+            }
+        });
+        ServerPlayNetworking.registerGlobalReceiver(SET_PLANK_ID, (server, player, handler, buf, responseSender) -> {
+
+            int plank = buf.readInt();
+            if (WoodWand.nextPlank.containsKey(player.getUuid())){
+                WoodWand.nextPlank.replace(player.getUuid(), plank); // Update if for some reason the player is cached
+            }
+            else {
+                WoodWand.nextPlank.put(player.getUuid(), plank); // Initialize with value
             }
         });
 

--- a/betterBuilding/src/main/java/legobrosbuild/betterbuilding/client/BetterBuildingClient.java
+++ b/betterBuilding/src/main/java/legobrosbuild/betterbuilding/client/BetterBuildingClient.java
@@ -6,10 +6,12 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.impl.item.ItemExtensions;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.option.StickyKeyBinding;
 import net.minecraft.network.PacketByteBuf;
@@ -23,6 +25,30 @@ public class BetterBuildingClient implements ClientModInitializer {
 
 
     public boolean locked = false;
+    public int nextPlank = 0;
+
+    public void setLocked(boolean state, MinecraftClient client) {
+        locked = state;
+        PacketByteBuf buf = PacketByteBufs.create();
+        buf.writeBoolean(locked);
+        ClientPlayNetworking.send(BetterBuilding.LOCK_WAND_ID, buf);
+        assert client.player != null;
+        // condition ? (result if true) : (result if false)
+        // Look up "ternary operator"
+        client.player.sendMessage(new LiteralText(locked ? "Locked" : "Unlocked").formatted(locked ? Formatting.GREEN : Formatting.RED), true);
+    }
+    public void setNextPlank(int state, MinecraftClient client) {
+        nextPlank = state;
+        PacketByteBuf buf = PacketByteBufs.create();
+        buf.writeInt(nextPlank);
+        ClientPlayNetworking.send(BetterBuilding.SET_PLANK_ID, buf);
+    }
+
+    public void restoreState(MinecraftClient client) {
+        setLocked(locked, client);
+        setNextPlank(nextPlank, client);
+    }
+
     @Override
     public void onInitializeClient() {
 
@@ -34,16 +60,13 @@ public class BetterBuildingClient implements ClientModInitializer {
 
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
             while (keyBinding.wasPressed()) {
-                locked = !locked;  // Flip *before* sending??
-                PacketByteBuf buf = PacketByteBufs.create();
-                buf.writeBoolean(locked);
-                ClientPlayNetworking.send(BetterBuilding.LOCK_WAND_ID, buf);
-                assert client.player != null;
-                // condition ? (result if true) : (result if false)
-                // Look up "ternary operator"
-                client.player.sendMessage(new LiteralText(locked ? "Locked" : "Unlocked").formatted(locked ? Formatting.GREEN : Formatting.RED), true);
+                setLocked(!locked, client);
             }
         });
+        ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> restoreState(client));
 
+        // send plank id from server to client
+        ClientPlayNetworking.registerGlobalReceiver(BetterBuilding.GET_CURRENT_PLANK, (client, handler, buf, responseSender) -> nextPlank = buf.readInt());
     }
+
 }


### PR DESCRIPTION
fancy features
## 2 new packets
* Client-to-Server: `SET_PLANK_ID` (`betterbuilding:setplank`) changes the plank that will be used with the Wood Wand
* Server-to-Client: `GET_CURRENT_PLANK` (`betterbuilding:getplank`) is sent to the client whenever the selected plank changes. Used for re-synchronization when connecting to a server.
## Other features
* Selected planks are now per-player